### PR TITLE
WIP: more flexible TextInput

### DIFF
--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -275,6 +275,8 @@ class TextInput extends React.Component<Props, State> {
       }),
     };
 
+    const placeholder = label ? this.state.placeholder : rest.placeholder; // display placeholder if no label wasn't passed
+
     return (
       <View style={style}>
         <AnimatedText
@@ -286,7 +288,7 @@ class TextInput extends React.Component<Props, State> {
         <NativeTextInput
           {...rest}
           value={value}
-          placeholder={this.state.placeholder}
+          placeholder={placeholder}
           placeholderTextColor={colors.placeholder}
           editable={!disabled}
           ref={this._setRef}

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -35,6 +35,10 @@ type Props = {
    */
   underlineColor?: string,
   /**
+   * Underline style of the input.
+   */
+  underlineStyle?: any,
+  /**
    * Whether the input can have multiple lines.
    */
   multiline?: boolean,
@@ -212,6 +216,7 @@ class TextInput extends React.Component<Props, State> {
       disabled,
       label,
       underlineColor,
+      underlineStyle,
       style,
       textInputStyle,
       theme,
@@ -304,7 +309,12 @@ class TextInput extends React.Component<Props, State> {
             style={[styles.bottomLine, { backgroundColor: inactiveColor }]}
           />
           <Animated.View
-            style={[styles.bottomLine, styles.focusLine, bottomLineStyle]}
+            style={[
+              styles.bottomLine,
+              styles.focusLine,
+              bottomLineStyle,
+              underlineStyle,
+            ]}
           />
         </View>
       </View>


### PR DESCRIPTION
### Motivation
#### What existing problem does the pull request solve?
It was impossible to change style(padding in my case) of the NativeTextInput.

#### Can you solve the issue with a different approach?
No.

#### Test plan
List the steps with which we can test this change. Provide screenshots if this changes anything visual.
just pass textInputStyle={{paddingTop: 0}} to the TextInput component.